### PR TITLE
Refresh CyberHubJo team profiles

### DIFF
--- a/Readme
+++ b/Readme
@@ -1,1 +1,32 @@
-Readme
+# CyberHubJo Website
+
+A static website for CyberHubJo featuring dedicated pages for the organisation's vision, team, publications, activities, resources, and contact information.
+
+## Pages
+
+- **Home** – Overview of CyberHubJo along with vision and mission statements.
+- **Our Team** – Profiles of seven core contributors with contact links.
+- **Publications** – Placeholder page noting that publications are to be announced.
+- **Activities** – Timeline highlighting milestones and community impact.
+- **Useful Resources** – Curated list of helpful articles and media content.
+- **Contact Us** – Primary contact email for enquiries.
+
+## Project Structure
+
+```
+assets/
+  css/
+    style.css   # Shared styling for all pages
+index.html       # Home page
+team.html        # Team profiles
+publications.html# Publications placeholder
+activities.html  # Activities timeline
+resources.html   # Useful resources
+contact.html     # Contact details
+```
+
+## Getting Started
+
+Open any of the HTML files directly in a browser, or run a lightweight local server (for example `python3 -m http.server`) and navigate to `http://localhost:8000/`.
+
+All navigation links are relative, so the pages work out of the box without additional configuration.

--- a/activities.html
+++ b/activities.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore CyberHubJo activities through our dynamic cybersecurity timeline."
+    />
+    <title>CyberHubJo | Activities</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html" aria-current="page">Activities</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Activities &amp; Impact</h1>
+            <p>
+              From community events to collaborative research sprints, our
+              initiatives strengthen Jordan&apos;s cybersecurity ecosystem and
+              nurture future-ready talent.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Milestones Timeline</h2>
+        <p class="section-intro">
+          Discover the journey of CyberHubJo through highlights of trainings,
+          partnerships, and strategic projects across the Kingdom.
+        </p>
+        <div class="timeline" role="list">
+          <article class="timeline-item" role="listitem">
+            <span>Q1 2024</span>
+            <h3>CyberHubJo officially launched</h3>
+            <p>
+              Hosted a national kickoff gathering with industry, academia, and
+              government partners to co-design our collaborative agenda.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>Q2 2024</span>
+            <h3>University cybersecurity bootcamps</h3>
+            <p>
+              Delivered immersive training for 150 students across three
+              Jordanian universities, focusing on incident response and secure
+              development practices.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>Q3 2024</span>
+            <h3>Threat intelligence sharing network</h3>
+            <p>
+              Established a trusted intelligence circle with 12 enterprises to
+              exchange timely insights on regional threat actors and TTPs.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>Q4 2024</span>
+            <h3>Public sector resilience workshops</h3>
+            <p>
+              Partnered with key ministries to assess critical infrastructure
+              risks and design policy-aligned mitigation roadmaps.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>2025 &amp; beyond</span>
+            <h3>Regional innovation challenges</h3>
+            <p>
+              Launching applied research competitions and incubator programs to
+              fast-track cybersecurity solutions across MENA markets.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,411 @@
+:root {
+  --primary-color: #0d47a1;
+  --secondary-color: #1b5ebe;
+  --accent-color: #ffc107;
+  --light-bg: #f5f7fb;
+  --text-color: #222;
+  --muted-text: #555;
+  --card-shadow: 0 15px 30px rgba(13, 71, 161, 0.08);
+  --border-radius: 16px;
+  --max-width: 1100px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Poppins', 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  color: var(--text-color);
+  background: linear-gradient(180deg, #ffffff 0%, #f7f9ff 100%);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--secondary-color);
+}
+
+header {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(13, 71, 161, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.nav-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.35rem;
+  color: var(--primary-color);
+  letter-spacing: 0.4px;
+}
+
+nav ul {
+  display: flex;
+  list-style: none;
+  gap: 24px;
+}
+
+nav a {
+  font-weight: 500;
+  color: var(--muted-text);
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+
+nav a[aria-current='page'] {
+  color: var(--primary-color);
+  font-weight: 600;
+  position: relative;
+}
+
+nav a[aria-current='page']::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 3px;
+  background: var(--accent-color);
+  border-radius: 999px;
+}
+
+main {
+  flex: 1;
+}
+
+.hero {
+  padding: 80px 24px;
+  background: linear-gradient(130deg, rgba(13, 71, 161, 0.09) 0%, rgba(13, 71, 161, 0.02) 100%);
+}
+
+.hero-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.3rem, 4vw, 3.2rem);
+  color: var(--primary-color);
+  margin-bottom: 20px;
+}
+
+.hero p {
+  color: var(--muted-text);
+  font-size: 1.05rem;
+}
+
+.section {
+  padding: 64px 24px;
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3.5vw, 2.6rem);
+  color: var(--primary-color);
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.section p.section-intro {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 40px;
+  color: var(--muted-text);
+}
+
+.cards {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card-header img {
+  width: 88px;
+  height: 88px;
+  border-radius: 16px;
+  object-fit: cover;
+  box-shadow: 0 8px 20px rgba(13, 71, 161, 0.18);
+  flex-shrink: 0;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(13, 71, 161, 0.12);
+}
+
+.card h3 {
+  color: var(--primary-color);
+  margin-bottom: 12px;
+  font-size: 1.25rem;
+}
+
+.card .role {
+  color: var(--secondary-color);
+  font-weight: 600;
+  margin-top: -6px;
+}
+
+.card .email {
+  margin-bottom: 0;
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.card .email a {
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+.card p {
+  color: var(--muted-text);
+  margin-bottom: 12px;
+}
+
+.card .links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.card .links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(13, 71, 161, 0.07);
+  color: var(--primary-color);
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.card .links a:hover,
+.card .links a:focus {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.timeline {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  position: relative;
+  padding-left: 20px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 28px;
+  top: 0;
+  height: 100%;
+  width: 3px;
+  background: linear-gradient(180deg, var(--primary-color), rgba(13, 71, 161, 0.1));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 32px;
+  padding-left: 48px;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 20px;
+  top: 8px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--primary-color);
+}
+
+.timeline-item h3 {
+  font-size: 1.2rem;
+  color: var(--primary-color);
+  margin-bottom: 6px;
+}
+
+.timeline-item span {
+  display: inline-block;
+  background: rgba(13, 71, 161, 0.12);
+  color: var(--primary-color);
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: 10px;
+  font-size: 0.85rem;
+}
+
+.timeline-item p {
+  color: var(--muted-text);
+}
+
+.resources {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.resources-section {
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+}
+
+.resources-section h3 {
+  color: var(--primary-color);
+  margin-bottom: 16px;
+}
+
+.resources-section ul {
+  list-style: disc;
+  padding-left: 24px;
+  color: var(--muted-text);
+}
+
+.contact-wrapper {
+  max-width: 720px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 32px;
+  box-shadow: var(--card-shadow);
+  text-align: center;
+}
+
+.contact-wrapper h2 {
+  margin-bottom: 16px;
+}
+
+.contact-wrapper p {
+  color: var(--muted-text);
+  margin-bottom: 24px;
+}
+
+.contact-wrapper a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--primary-color);
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-wrapper a:hover,
+.contact-wrapper a:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 35px rgba(13, 71, 161, 0.25);
+}
+
+footer {
+  margin-top: auto;
+  background: #0c1a3a;
+  color: rgba(255, 255, 255, 0.78);
+  text-align: center;
+  padding: 24px 16px;
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: #fff;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .card-header {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .card-header div {
+    text-align: center;
+  }
+
+  .card-header img {
+    width: 96px;
+    height: 96px;
+  }
+
+  .card .email {
+    text-align: center;
+  }
+}
+
+@media (max-width: 768px) {
+  nav ul {
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .timeline::before {
+    left: 18px;
+  }
+
+  .timeline-item {
+    padding-left: 46px;
+  }
+
+  .timeline-item::before {
+    left: 10px;
+  }
+}

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Get in touch with CyberHubJo for partnerships, programs, and cybersecurity collaboration."
+    />
+    <title>CyberHubJo | Contact Us</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html" aria-current="page">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Contact CyberHubJo</h1>
+            <p>
+              We welcome partnerships, research collaborations, volunteer
+              interest, and opportunities to empower Jordan&apos;s cybersecurity
+              ecosystem.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="contact-wrapper">
+          <h2>We&apos;d love to hear from you</h2>
+          <p>
+            Email our team and we&apos;ll respond promptly with the information or
+            support you need.
+          </p>
+          <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CyberHubJo empowers Jordan's cybersecurity community through research, collaboration, and capacity building."
+    />
+    <title>CyberHubJo | Advancing Cybersecurity in Jordan</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Building a resilient and secure digital Jordan</h1>
+            <p>
+              CyberHubJo unites researchers, practitioners, and innovators to
+              accelerate cybersecurity capabilities through collaboration,
+              knowledge sharing, and impactful initiatives across the Kingdom.
+            </p>
+          </div>
+          <div class="card" role="presentation">
+            <h3>What we do</h3>
+            <p>
+              We connect academic, public, and private sector experts to
+              translate cyber research into real-world solutions, nurture local
+              talent, and elevate national resilience.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="vision">
+        <div class="cards">
+          <article class="card" id="vision">
+            <h2>Our Vision</h2>
+            <p>
+              To become Jordan&apos;s leading cybersecurity knowledge hub,
+              empowering individuals and institutions with trusted insights and
+              resources to safeguard the nation&apos;s digital future.
+            </p>
+          </article>
+          <article class="card" id="mission">
+            <h2>Our Mission</h2>
+            <p>
+              To advance cybersecurity excellence through collaborative
+              research, community-driven initiatives, and inclusive programs
+              that cultivate innovation, awareness, and readiness across all
+              sectors in Jordan.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CyberHubJo publications, case studies, and research will be announced soon."
+    />
+    <title>CyberHubJo | Publications</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html" aria-current="page">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Publications</h1>
+            <p>
+              Our research papers, case studies, and insight reports will be
+              shared soon. Stay tuned for updates as we finalize our inaugural
+              publications.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="cards">
+          <article class="card" aria-live="polite">
+            <h2>Coming Soon</h2>
+            <p>
+              The CyberHubJo publications library is in development. We are
+              curating thought leadership and collaborative research to support
+              practitioners, policymakers, and learners.
+            </p>
+            <p><strong>To be announced.</strong></p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Access CyberHubJo curated articles and media resources that strengthen cybersecurity skills."
+    />
+    <title>CyberHubJo | Useful Resources</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="resources.html" aria-current="page">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Useful Resources</h1>
+            <p>
+              Curated knowledge to help practitioners, students, and leaders
+              stay ahead of cyber risks, trends, and innovations.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Explore by Category</h2>
+        <p class="section-intro">
+          Browse featured articles and multimedia content that support learning
+          journeys at every stage.
+        </p>
+        <div class="resources">
+          <section class="resources-section" aria-labelledby="articles">
+            <h3 id="articles">Articles</h3>
+            <ul>
+              <li>
+                <a href="https://www.cisa.gov/topics/cybersecurity-best-practices" target="_blank" rel="noopener">
+                  CISA Cybersecurity Best Practices
+                </a>
+                – actionable guides for building resilient systems.
+              </li>
+              <li>
+                <a href="https://www.enisa.europa.eu/topics/csirt-cert-services/incident-response" target="_blank" rel="noopener">
+                  ENISA Incident Response Playbooks
+                </a>
+                – step-by-step resources for CSIRT teams.
+              </li>
+              <li>
+                <a href="https://www.first.org/resources/papers" target="_blank" rel="noopener">
+                  FIRST Community Papers
+                </a>
+                – global perspectives on collaborative security operations.
+              </li>
+            </ul>
+          </section>
+
+          <section class="resources-section" aria-labelledby="media">
+            <h3 id="media">Media</h3>
+            <ul>
+              <li>
+                <a href="https://www.youtube.com/c/CyberSecuritySummit" target="_blank" rel="noopener">
+                  Cyber Security Summit Channel
+                </a>
+                – thought-provoking conference talks and panel discussions.
+              </li>
+              <li>
+                <a href="https://www.youtube.com/playlist?list=PLCO7dTO0PvEHV3HNsx3Rp3XIanFkF_jxK" target="_blank" rel="noopener">
+                  Google Security Talks Playlist
+                </a>
+                – expert deep dives into threat intelligence and defense.
+              </li>
+              <li>
+                <a href="https://open.spotify.com/show/4EwUhpLwHxZ34rnOG0r8Qd" target="_blank" rel="noopener">
+                  CyberWire Daily Podcast
+                </a>
+                – daily briefings on cyber events shaping the world.
+              </li>
+            </ul>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Meet the CyberHubJo core team of cybersecurity researchers, architects, and community leaders."
+    />
+    <title>CyberHubJo | Our Team</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">CyberHubJo</a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html" aria-current="page">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>The minds powering CyberHubJo</h1>
+            <p>
+              Our multidisciplinary team blends academic excellence, industry
+              expertise, and community leadership to drive impactful
+              cybersecurity programs for Jordan and the region.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Leadership &amp; Contributors</h2>
+        <p class="section-intro">
+          Each member brings a unique perspective to strengthening Jordan&apos;s
+          cyber defense posture through research, innovation, and outreach.
+        </p>
+        <div class="cards" role="list">
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Hatem+Mosa&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Hatem Mosa"
+                loading="lazy"
+              />
+              <div>
+                <h3>Hatem Mosa</h3>
+                <p class="role">Cybersecurity Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:h.mosa@cyberhubjo.com">h.mosa@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Hatem Mosa is a cybersecurity specialist and PhD candidate at
+              Princess Sumaya University for Technology (PSUT), where he also
+              serves as a research assistant. His research focuses on
+              cybersecurity and blockchain technologies. He is the founder of
+              HatemTech, a Bahrain-based non-profit organization that promotes
+              cybersecurity awareness across the MENA region. With over a
+              decade of experience in IT and cybersecurity, Hatem also holds a
+              Master’s in Cybersecurity from Arizona State University and
+              several industry certifications from Microsoft, Cisco, IBM, and
+              EC-Council.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/hatem-mosa" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=DIjlcAYAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Hatem-Mosa-2?ev=hdr_xprf" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Ebtehal+Omoush&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Ebtehal Omoush"
+                loading="lazy"
+              />
+              <div>
+                <h3>Ebtehal Omoush</h3>
+                <p class="role">Scientific Events Coordinator</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:e.omoush@cyberhubjo.com">e.omoush@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Ebtehal Hamdan Omoush is a Ph.D. candidate in the Computer
+              Science Department at Princess Sumaya University for Technology
+              (PSUT), Amman, Jordan. She started her Ph.D. study in 2022. She
+              received her M.Sc. degree in Computer Science in 2012 from Al
+              al-Bayt University and her B.Sc. degree in Computer Information
+              Systems in 2009 from the same institution. She is currently
+              working at Al al-Bayt University, Mafraq, Jordan.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/ebtehal-omoush-76659645/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=WIvIULEAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Ebtehal-Omoush-2" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Amro+Saleh&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Amro Saleh"
+                loading="lazy"
+              />
+              <div>
+                <h3>Amro Saleh</h3>
+                <p class="role">Scientific Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:a.saleh@cyberhubjo.com">a.saleh@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Amro Saleh is an academic researcher and Ph.D. candidate in
+              Computer Science at Princess Sumaya University for Technology
+              (PSUT). He holds a master’s degree in computer engineering from
+              the German Jordanian University and a bachelor’s degree in
+              computer science from the University of Jordan. His research
+              focuses on distributed data and AI systems, with a particular
+              interest in developing secure and scalable AI techniques for
+              real-world applications across big data and cloud computing
+              domains. With long-standing industry experience complementing his
+              academic journey, Amro brings a unique balance of practical
+              insight and theoretical depth. His work bridges innovation with
+              implementation, addressing critical challenges in decentralized
+              data environments, model integrity, and trustworthy AI. He is
+              actively involved in scholarly publishing, collaborative
+              research, and academic outreach, and is committed to shaping the
+              next generation of secure, ethical, and inclusive data and AI
+              technologies.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/amro-saleh-b50ab720a/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=O94CIikAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Amro-Saleh/research" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Eman+Alnagi&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Eman Alnagi"
+                loading="lazy"
+              />
+              <div>
+                <h3>Eman Alnagi</h3>
+                <p class="role">Research Associate</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:e.alnagi@cyberhubjo.com">e.alnagi@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Eman Alnagi is a Ph.D. candidate in the Computer Science
+              Department at Princess Sumaya University for Technology (PSUT) in
+              Jordan. She started her Ph.D. study in 2021. She has graduated
+              from Yarmouk University with a B.Sc. in Computer Science, from
+              the University of Sunderland with an M.Sc. in Information
+              Technology Management, and also from PSUT with an M.Sc. in
+              Computer Science. She has started her career as a software
+              engineer and then as a development team leader in computer
+              companies in Jordan, and lasted for six years. She has 11 years
+              of experience as a university lecturer at Philadelphia University
+              in Jordan. Her research interests are mainly in natural language
+              processing, cryptography, artificial intelligence, cybersecurity,
+              and digital image processing.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/eman-alnagi/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=4xD9oKgAAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Eman-Alnagi?ev=prf_overview" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Yasmeen+Alslman&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Yasmeen Alslman"
+                loading="lazy"
+              />
+              <div>
+                <h3>Yasmeen Alslman</h3>
+                <p class="role">Scientific Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:y.alslman@cyberhubjo.com">y.alslman@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Yasmeen Alslman is a Ph.D. candidate and a former master’s
+              student in Computer Science at Princess Sumaya University for
+              Technology (PSUT) in Jordan. She graduated from Jordan University
+              with a bachelor&apos;s in Computer Science in 2018. Her academic
+              journey reflects a commitment to cybersecurity and AI research,
+              with a particular focus on adversarial machine learning,
+              intrusion detection systems (IDS), and cryptography. She is
+              passionate about developing intelligent defense mechanisms that
+              adapt to evolving cyber threats in AI. Recently, she has also
+              begun exploring large language models (LLMs), with the goal of
+              understanding their potential in mathematical modeling.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/yasmeen-alslman-61468a198/?originalSubdomain=jo" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=5gHaQkoAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Yasmeen-Alslman" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=Saleem+Alsaraireh&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of Saleem Alsaraireh"
+                loading="lazy"
+              />
+              <div>
+                <h3>Saleem Alsaraireh</h3>
+                <p class="role">Cybersecurity Academic Liaison Officer</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:s.alsaraireh@cyberhubjo.com">s.alsaraireh@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              Saleem Alsaraireh is a dedicated Ph.D. candidate in Computer
+              Science at Princess Sumaya University for Technology (PSUT),
+              Jordan, where he has been pursuing advanced research since 2021.
+              With a strong academic foundation, he earned his Bachelor of
+              Science in Computer Information Systems with excellent honors
+              (First in Class) from Mutah University (Military Wing)
+              (2005&ndash;2009) and later achieved a Master of Science in Computer
+              Science with excellent standing from Mu&apos;tah University
+              (2015&ndash;2017). A professional with more than 17 years of
+              experience, Saleem serves as an officer in the Jordan Armed
+              Forces (JAF), specializing in communications and technical
+              support. Currently holding the rank of Lieutenant Colonel, he
+              contributes his expertise at the Naser Bin Jameel College for
+              Military Communications, where he plays a key role in advancing
+              military communications technology and training. His academic
+              pursuits and military career reflect a deep commitment to
+              technology, leadership, and innovation, positioning him as a
+              valuable contributor to both academia and defense communications.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/saleem-alsaraireh-aa6611352/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=V_GTO78AAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Saleem-Alsaraireh" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://ui-avatars.com/api/?name=AbedlRahman+Almodawar&amp;background=0D47A1&amp;color=fff&amp;size=256"
+                alt="Portrait of AbedlRahman Almodawar"
+                loading="lazy"
+              />
+              <div>
+                <h3>AbedlRahman Almodawar</h3>
+                <p class="role">Research Publication Coordinator</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:a.almodawar@cyberhubjo.com">a.almodawar@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p>
+              AbedlRahman Almodawar is a Ph.D. candidate in the Computer
+              Science Department at Princess Sumaya University for Technology,
+              Jordan, where he began his doctoral studies in 2021. He earned
+              his B.Sc. in Computer Science from Al-Balqa Applied University,
+              Jordan, in 2010 and his M.Sc. in Computer Science from Jordan
+              University of Science and Technology, Jordan, in 2013. With over
+              14 years of experience in higher education, he has worked as a
+              full-time lecturer at Granada Intermediate University College
+              since 2011 and at Jordan University of Science and Technology
+              since 2014. His research interests focus on artificial
+              intelligence, cloud and edge computing (IoT), and cybersecurity.
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/abedlrahman-almodawar-74b90128/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=fl0s05oAAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Abedlrahman-Almodawar?ev=hdr_xprf" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the placeholder leadership roster with official CyberHubJo member bios, contact addresses, and research profile links
- add profile header styling so each team card features an avatar, role, and responsive contact details

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68c9732d5474832dbc5f99dc730c741b