### PR TITLE
Preserve all team cards during shuffle

### DIFF
--- a/Readme
+++ b/Readme
@@ -1,1 +1,36 @@
-Readme
+# CyberHubJo Website
+
+A static website for CyberHubJo featuring dedicated pages for the organisation's vision, team, publications, activities, media gallery, resources, and contact information.
+
+## Pages
+
+- **Home** – Overview of CyberHubJo along with vision and mission statements.
+- **Our Team** – Profiles of seven core contributors with contact links.
+- **Publications** – Placeholder page noting that publications are to be announced.
+- **Activities** – Timeline highlighting milestones and community impact.
+- **Gallery** – Video highlights paired with their LinkedIn context.
+- **Useful Resources** – Curated list of helpful articles and media content.
+- **Contact Us** – Primary contact email for enquiries.
+
+## Project Structure
+
+```
+assets/
+  css/
+    style.css   # Shared styling for all pages
+  js/
+    main.js     # Shared behaviour for navigation and footer year
+index.html       # Home page
+team.html        # Team profiles
+publications.html# Publications placeholder
+activities.html  # Activities timeline
+gallery.html     # Media highlights with LinkedIn links
+resources.html   # Useful resources
+contact.html     # Contact details
+```
+
+## Getting Started
+
+Open any of the HTML files directly in a browser, or run a lightweight local server (for example `python3 -m http.server`) and navigate to `http://localhost:8000/`.
+
+All navigation links are relative, so the pages work out of the box without additional configuration.

--- a/activities.html
+++ b/activities.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore CyberHubJo activities through our dynamic cybersecurity timeline."
+    />
+    <title>CyberHubJo | Activities</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html" aria-current="page">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Activities &amp; Impact</h1>
+            <p>
+              From community events to collaborative research sprints, our
+              initiatives strengthen Jordan&apos;s cybersecurity ecosystem and
+              nurture future-ready talent.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Milestones Timeline</h2>
+        <p class="section-intro">
+          Discover the journey of CyberHubJo through highlights of trainings,
+          partnerships, and strategic projects across the Kingdom.
+        </p>
+        <div class="timeline" role="list">
+          <article class="timeline-item" role="listitem">
+            <span>March 2024</span>
+            <h3>The spark</h3>
+            <p>
+              Hatem Mosa pitched the CyberHubJo vision to fellow PhD students,
+              planting the seed for a collaborative cybersecurity collective.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>March 2025</span>
+            <h3>Momentum from PSUT leadership</h3>
+            <p>
+              Following an inspiring conversation with the PSUT presidency, the
+              founding members aligned on announcing CyberHubJo to the wider
+              community.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>April 2025</span>
+            <h3>Vision building sessions</h3>
+            <p>
+              Weekly workshops kicked off to refine the initiative&apos;s mission,
+              values, and impact areas while shaping the brand identity.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>May 2025</span>
+            <h3>Knowledge sharing begins</h3>
+            <p>
+              Members started hosting recurring meetups to exchange ideas and
+              deliver hands-on cybersecurity trainings every week.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>June 2025</span>
+            <h3>LinkedIn community launch</h3>
+            <p>
+              The CyberHubJo LinkedIn group opened to the public, creating a
+              digital hub to celebrate achievements and connect with partners
+              across the globe.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>July 2025</span>
+            <h3>First in-person gathering</h3>
+            <p>
+              The team met face-to-face to workshop their debut research paper,
+              strengthen collaboration, and realign responsibilities.
+            </p>
+          </article>
+
+          <article class="timeline-item" role="listitem">
+            <span>October 2025</span>
+            <h3>Website debut</h3>
+            <p>
+              CyberHubJo&apos;s official website went live, providing a central
+              destination for activities, publications, and community updates.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,684 @@
+:root {
+  --primary-color: #0d47a1;
+  --secondary-color: #1b5ebe;
+  --accent-color: #ffc107;
+  --light-bg: #f5f7fb;
+  --text-color: #222;
+  --muted-text: #555;
+  --card-shadow: 0 15px 30px rgba(13, 71, 161, 0.08);
+  --border-radius: 16px;
+  --max-width: 1100px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Poppins', 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  color: var(--text-color);
+  background: linear-gradient(180deg, #ffffff 0%, #f7f9ff 100%);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--secondary-color);
+}
+
+header {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(13, 71, 161, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.nav-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  gap: 24px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 1.35rem;
+  color: var(--primary-color);
+  letter-spacing: 0.4px;
+}
+
+.brand-logo {
+  width: 64px;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  object-fit: contain;
+  border-radius: 12px;
+  box-shadow: 0 8px 16px rgba(13, 71, 161, 0.15);
+  background: #fff;
+}
+
+.brand-name {
+  display: inline-block;
+}
+
+nav {
+  margin-left: auto;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  gap: 24px;
+}
+
+.nav-toggle {
+  display: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 8px;
+  margin-left: auto;
+  border-radius: 8px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: var(--primary-color);
+  border-radius: 999px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle span + span {
+  margin-top: 6px;
+}
+
+.nav-links a {
+  font-weight: 500;
+  color: var(--muted-text);
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+
+.nav-toggle:focus-visible,
+.nav-links a:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 4px;
+}
+
+.nav-links a[aria-current='page'] {
+  color: var(--primary-color);
+  font-weight: 600;
+  position: relative;
+}
+
+.nav-links a[aria-current='page']::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 3px;
+  background: var(--accent-color);
+  border-radius: 999px;
+}
+
+.nav-toggle[aria-expanded='true'] span:nth-child(1) {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded='true'] span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-toggle[aria-expanded='true'] span:nth-child(3) {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+main {
+  flex: 1;
+}
+
+.hero {
+  position: relative;
+  padding: 80px 24px;
+  background: linear-gradient(130deg, rgba(13, 71, 161, 0.6) 0%, rgba(13, 71, 161, 0.35) 100%);
+  overflow: hidden;
+}
+
+.hero--video {
+  background: #030b1f;
+}
+
+.hero-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  filter: brightness(0.55) saturate(1.2);
+  z-index: 0;
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(3, 11, 31, 0.85) 0%, rgba(13, 71, 161, 0.55) 100%);
+  z-index: 1;
+}
+
+.hero-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+  position: relative;
+  z-index: 2;
+}
+
+.hero--video .hero-content h1 {
+  color: #f5f9ff;
+}
+
+.hero--video .hero-content p {
+  color: rgba(245, 249, 255, 0.85);
+}
+
+.hero--video .card {
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--text-color);
+}
+
+.hero--video .card h3 {
+  color: var(--primary-color);
+}
+
+.hero--video .card p {
+  color: var(--muted-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-video {
+    display: none;
+  }
+
+  .hero-overlay {
+    background: linear-gradient(130deg, rgba(3, 11, 31, 0.9) 0%, rgba(13, 71, 161, 0.65) 100%);
+  }
+}
+
+.hero h1 {
+  font-size: clamp(2.3rem, 4vw, 3.2rem);
+  color: var(--primary-color);
+  margin-bottom: 20px;
+}
+
+.hero p {
+  color: var(--muted-text);
+  font-size: 1.05rem;
+}
+
+.section {
+  padding: 64px 24px;
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3.5vw, 2.6rem);
+  color: var(--primary-color);
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.section p.section-intro {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 40px;
+  color: var(--muted-text);
+}
+
+.cards {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.cards.media-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.cards.team-grid {
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  justify-content: center;
+  justify-items: stretch;
+}
+
+.cards.team-grid .team-card {
+  width: 100%;
+}
+
+.cards.team-grid .team-card--solo {
+  grid-column: 1 / -1;
+  max-width: min(520px, 100%);
+  justify-self: center;
+}
+
+.cards.team-grid .card-founder {
+  border: 2px solid rgba(255, 193, 7, 0.4);
+  box-shadow: 0 20px 40px rgba(13, 71, 161, 0.15);
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.media-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.media-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.media-card__meta a {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--primary-color);
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(13, 71, 161, 0.1);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.media-card__meta a:hover,
+.media-card__meta a:focus {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.media-card video {
+  width: 100%;
+  border-radius: calc(var(--border-radius) - 4px);
+  box-shadow: 0 12px 24px rgba(13, 71, 161, 0.18);
+  background: #000;
+  aspect-ratio: 16 / 9;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card-header img {
+  width: 88px;
+  height: 88px;
+  border-radius: 16px;
+  object-fit: cover;
+  box-shadow: 0 8px 20px rgba(13, 71, 161, 0.18);
+  flex-shrink: 0;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(13, 71, 161, 0.12);
+}
+
+.card h3 {
+  color: var(--primary-color);
+  margin-bottom: 12px;
+  font-size: 1.25rem;
+}
+
+.card .role {
+  color: var(--secondary-color);
+  font-weight: 600;
+  margin-top: -6px;
+}
+
+.card .email {
+  margin-bottom: 0;
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.card .email a {
+  color: var(--primary-color);
+  font-weight: 600;
+  display: inline-block;
+  overflow-wrap: anywhere;
+}
+
+.card p {
+  color: var(--muted-text);
+  margin-bottom: 12px;
+}
+
+.card .bio {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 193, 7, 0.18);
+  color: var(--primary-color);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.badge::before {
+  content: '★';
+  font-size: 0.75rem;
+  color: var(--accent-color);
+}
+
+.card .links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.card .links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(13, 71, 161, 0.07);
+  color: var(--primary-color);
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.card .links a:hover,
+.card .links a:focus {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.timeline {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  position: relative;
+  padding-left: 20px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 28px;
+  top: 0;
+  height: 100%;
+  width: 3px;
+  background: linear-gradient(180deg, var(--primary-color), rgba(13, 71, 161, 0.1));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 32px;
+  padding-left: 48px;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 20px;
+  top: 8px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid var(--primary-color);
+}
+
+.timeline-item h3 {
+  font-size: 1.2rem;
+  color: var(--primary-color);
+  margin-bottom: 6px;
+}
+
+.timeline-item span {
+  display: inline-block;
+  background: rgba(13, 71, 161, 0.12);
+  color: var(--primary-color);
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: 10px;
+  font-size: 0.85rem;
+}
+
+.timeline-item p {
+  color: var(--muted-text);
+}
+
+.resources {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.resources-section {
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 24px;
+  box-shadow: var(--card-shadow);
+}
+
+.resources-section h3 {
+  color: var(--primary-color);
+  margin-bottom: 16px;
+}
+
+.resources-section ul {
+  list-style: disc;
+  padding-left: 24px;
+  color: var(--muted-text);
+}
+
+.contact-wrapper {
+  max-width: 720px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: 32px;
+  box-shadow: var(--card-shadow);
+  text-align: center;
+}
+
+.contact-wrapper h2 {
+  margin-bottom: 16px;
+}
+
+.contact-wrapper p {
+  color: var(--muted-text);
+  margin-bottom: 24px;
+}
+
+.contact-wrapper a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--primary-color);
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-wrapper a:hover,
+.contact-wrapper a:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 35px rgba(13, 71, 161, 0.25);
+}
+
+footer {
+  margin-top: auto;
+  background: #0c1a3a;
+  color: rgba(255, 255, 255, 0.78);
+  text-align: center;
+  padding: 24px 16px;
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: #fff;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .nav-toggle {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0;
+  }
+
+  nav {
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 24px;
+    left: 24px;
+    z-index: 1000;
+  }
+
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.97);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--card-shadow);
+  }
+
+  .nav-links.is-open {
+    display: flex;
+  }
+
+  .nav-links li {
+    width: 100%;
+  }
+
+  .nav-links a {
+    display: block;
+    width: 100%;
+    padding: 8px 0;
+  }
+}
+
+@media (max-width: 480px) {
+  nav {
+    left: 16px;
+    right: 16px;
+  }
+
+  .brand-logo {
+    width: 52px;
+  }
+}
+
+@media (max-width: 600px) {
+  .card-header {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .card-header div {
+    text-align: center;
+  }
+
+  .card-header img {
+    width: 96px;
+    height: 96px;
+  }
+
+  .card .email {
+    text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .cards.team-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .timeline::before {
+    left: 18px;
+  }
+
+  .timeline-item {
+    padding-left: 46px;
+  }
+
+  .timeline-item::before {
+    left: 10px;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,85 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearElement = document.getElementById('year');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear();
+  }
+
+  const navToggle = document.querySelector('.nav-toggle');
+  const navLinks = document.getElementById('primary-navigation');
+
+  if (navToggle && navLinks) {
+    const closeNavigation = () => {
+      navLinks.classList.remove('is-open');
+      navToggle.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('nav-open');
+    };
+
+    navToggle.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      navLinks.classList.toggle('is-open');
+      document.body.classList.toggle('nav-open', !expanded);
+    });
+
+    navLinks.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLElement && event.target.matches('a')) {
+        closeNavigation();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navLinks.classList.contains('is-open')) {
+        closeNavigation();
+        navToggle.focus();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 900 && navLinks.classList.contains('is-open')) {
+        closeNavigation();
+      }
+    });
+  }
+
+  const teamGrid = document.querySelector('.team-grid');
+  if (teamGrid) {
+    const cards = Array.from(teamGrid.querySelectorAll('.team-card'));
+    const founderCard = cards.find((card) => card.classList.contains('card-founder'));
+
+    if (founderCard && cards.length > 1) {
+      cards.forEach((card) => {
+        card.classList.remove('team-card--solo');
+        card.style.removeProperty('order');
+      });
+
+      const otherCards = cards.filter((card) => card !== founderCard);
+
+      for (let i = otherCards.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [otherCards[i], otherCards[j]] = [otherCards[j], otherCards[i]];
+      }
+
+      const orderedCards = [founderCard];
+
+      const partner = otherCards.shift();
+      if (partner) {
+        orderedCards.push(partner);
+      }
+
+      orderedCards.push(...otherCards);
+
+      const totalCards = orderedCards.length;
+
+      orderedCards.forEach((card, index) => {
+        card.style.order = String(index);
+      });
+
+      if (totalCards % 2 !== 0) {
+        const lastCard = orderedCards[totalCards - 1];
+        if (lastCard !== founderCard) {
+          lastCard.classList.add('team-card--solo');
+        }
+      }
+    }
+  }
+});

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Get in touch with CyberHubJo for partnerships, programs, and cybersecurity collaboration."
+    />
+    <title>CyberHubJo | Contact Us</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html" aria-current="page">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Contact CyberHubJo</h1>
+            <p>
+              We welcome partnerships, research collaborations, volunteer
+              interest, and opportunities to empower Jordan&apos;s cybersecurity
+              ecosystem.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="contact-wrapper">
+          <h2>We&apos;d love to hear from you</h2>
+          <p>
+            Email our team and we&apos;ll respond promptly with the information or
+            support you need.
+          </p>
+          <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Watch CyberHubJo event highlights and community moments captured in video."
+    />
+    <title>CyberHubJo | Gallery</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html" aria-current="page">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Gallery</h1>
+            <p>
+              Relive CyberHubJo milestones through curated videos, capturing our
+              community&apos;s collaboration, partnerships, and on-site energy.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Media Highlights</h2>
+        <p class="section-intro">
+          Explore our latest LinkedIn updates and immersive clips showcasing
+          CyberHubJo&apos;s growth and engagement with the cybersecurity community.
+        </p>
+        <div class="cards media-grid" role="list">
+          <article class="card media-card" role="listitem">
+            <video controls preload="metadata">
+              <source
+                src="https://files.cyberhubjo.com/CyberHubJo%20Meeting%231%20READY.mp4"
+                type="video/mp4"
+              />
+              Your browser does not support the video tag.
+            </video>
+            <div class="media-card__meta">
+              <h3>CyberHubJo Kickoff Meeting</h3>
+              <a
+                href="https://www.linkedin.com/feed/update/urn:li:activity:7344355784748662788?utm_source=share&utm_medium=member_desktop&rcm=ACoAABX29WcBuYibfh3xHcakvRlMumEo3Ks20ro"
+                target="_blank"
+                rel="noopener"
+              >
+                View LinkedIn post
+              </a>
+              <p>
+                We&apos;re thrilled to share highlights from the very first meeting
+                of CyberHubJo. Together, members aligned on a strategic action
+                plan that advances our mission, vision, and long-term goals.
+              </p>
+              <p>
+                As PhD candidates, one of our core objectives is to actively
+                contribute to the global academic community by publishing
+                high-quality research. The journey has just begun!
+              </p>
+            </div>
+          </article>
+
+          <article class="card media-card" role="listitem">
+            <video controls preload="metadata">
+              <source
+                src="https://files.cyberhubjo.com/CyberHubJo%20Meeting%239%20READY%20Compressed.mp4"
+                type="video/mp4"
+              />
+              Your browser does not support the video tag.
+            </video>
+            <div class="media-card__meta">
+              <h3>Connecting Global Expertise</h3>
+              <a
+                href="https://www.linkedin.com/feed/update/urn:li:activity:7358872321849208832?utm_source=share&utm_medium=member_desktop&rcm=ACoAABX29WcBuYibfh3xHcakvRlMumEo3Ks20ro"
+                target="_blank"
+                rel="noopener"
+              >
+                View LinkedIn post
+              </a>
+              <p>
+                At CyberHubJo, our mission is to bridge the gap between academia
+                and industry while fostering global collaboration in
+                cybersecurity research and innovation.
+              </p>
+              <p>
+                We met with leading Bahraini cybersecurity expert Ahmed Altayeb
+                to exchange insights, explore ideas, and tackle real-world
+                challenges in the cybersecurity domain.
+              </p>
+            </div>
+          </article>
+
+          <article class="card media-card" role="listitem">
+            <video controls preload="metadata">
+              <source
+                src="https://files.cyberhubjo.com/Meeting%20%2311%20Ready.mp4"
+                type="video/mp4"
+              />
+              Your browser does not support the video tag.
+            </video>
+            <div class="media-card__meta">
+              <h3>On-Premises Meeting Moments</h3>
+              <a
+                href="https://www.linkedin.com/feed/update/urn:li:activity:7371517291894841344?utm_source=share&utm_medium=member_desktop&rcm=ACoAABX29WcBuYibfh3xHcakvRlMumEo3Ks20ro"
+                target="_blank"
+                rel="noopener"
+              >
+                View LinkedIn post
+              </a>
+              <p>
+                While online meetings keep us connected, in-person gatherings
+                bring a unique energy. We loved discussing our upcoming research
+                paper and sharing pizzas, courtesy of Yasmeen Alslman.
+              </p>
+              <p>
+                Enjoy this two-minute recap from our on-premises meetup and feel
+                the momentum driving CyberHubJo forward.
+              </p>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CyberHubJo empowers Jordan's cybersecurity community through research, collaboration, and capacity building."
+    />
+    <title>CyberHubJo | Advancing Cybersecurity in Jordan</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html" aria-current="page">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero hero--video">
+        <video
+          class="hero-video"
+          src="https://files.cyberhubjo.com/Intro_without_watermark.mp4"
+          autoplay
+          muted
+          loop
+          playsinline
+          aria-hidden="true"
+        ></video>
+        <div class="hero-overlay" aria-hidden="true"></div>
+        <div class="hero-content">
+          <div>
+            <h1>Building a resilient and secure digital Jordan</h1>
+            <p>
+              CyberHubJo unites researchers, practitioners, and innovators to
+              accelerate cybersecurity capabilities through collaboration,
+              knowledge sharing, and impactful initiatives across the Kingdom.
+            </p>
+          </div>
+          <div class="card" role="presentation">
+            <h3>What we do</h3>
+            <p>
+              We connect academic, public, and private sector experts to
+              translate cyber research into real-world solutions, nurture local
+              talent, and elevate national resilience.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="vision">
+        <div class="cards">
+          <article class="card" id="vision">
+            <h2>Our Vision</h2>
+            <p>
+              To become Jordan&apos;s leading cybersecurity knowledge hub,
+              empowering individuals and institutions with trusted insights and
+              resources to safeguard the nation&apos;s digital future.
+            </p>
+          </article>
+          <article class="card" id="mission">
+            <h2>Our Mission</h2>
+            <p>
+              To advance cybersecurity excellence through collaborative
+              research, community-driven initiatives, and inclusive programs
+              that cultivate innovation, awareness, and readiness across all
+              sectors in Jordan.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CyberHubJo publications, case studies, and research will be announced soon."
+    />
+    <title>CyberHubJo | Publications</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html" aria-current="page">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Publications</h1>
+            <p>
+              Our research papers, case studies, and insight reports will be
+              shared soon. Stay tuned for updates as we finalize our inaugural
+              publications.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="cards">
+          <article class="card" aria-live="polite">
+            <h2>Coming Soon</h2>
+            <p>
+              The CyberHubJo publications library is in development. We are
+              curating thought leadership and collaborative research to support
+              practitioners, policymakers, and learners.
+            </p>
+            <p><strong>To be announced.</strong></p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Access CyberHubJo curated articles and media resources that strengthen cybersecurity skills."
+    />
+    <title>CyberHubJo | Useful Resources</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html" aria-current="page">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>Useful Resources</h1>
+            <p>
+              Curated knowledge to help practitioners, students, and leaders
+              stay ahead of cyber risks, trends, and innovations.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Explore by Category</h2>
+        <p class="section-intro">
+          Browse featured articles and multimedia content that support learning
+          journeys at every stage.
+        </p>
+        <div class="resources">
+          <section class="resources-section" aria-labelledby="articles">
+            <h3 id="articles">Articles</h3>
+            <ul>
+              <li>
+                <a href="https://www.cisa.gov/topics/cybersecurity-best-practices" target="_blank" rel="noopener">
+                  CISA Cybersecurity Best Practices
+                </a>
+                – actionable guides for building resilient systems.
+              </li>
+              <li>
+                <a href="https://www.enisa.europa.eu/topics/csirt-cert-services/incident-response" target="_blank" rel="noopener">
+                  ENISA Incident Response Playbooks
+                </a>
+                – step-by-step resources for CSIRT teams.
+              </li>
+              <li>
+                <a href="https://www.first.org/resources/papers" target="_blank" rel="noopener">
+                  FIRST Community Papers
+                </a>
+                – global perspectives on collaborative security operations.
+              </li>
+            </ul>
+          </section>
+
+          <section class="resources-section" aria-labelledby="media">
+            <h3 id="media">Media</h3>
+            <ul>
+              <li>
+                <a href="https://www.youtube.com/c/CyberSecuritySummit" target="_blank" rel="noopener">
+                  Cyber Security Summit Channel
+                </a>
+                – thought-provoking conference talks and panel discussions.
+              </li>
+              <li>
+                <a href="https://www.youtube.com/playlist?list=PLCO7dTO0PvEHV3HNsx3Rp3XIanFkF_jxK" target="_blank" rel="noopener">
+                  Google Security Talks Playlist
+                </a>
+                – expert deep dives into threat intelligence and defense.
+              </li>
+              <li>
+                <a href="https://open.spotify.com/show/4EwUhpLwHxZ34rnOG0r8Qd" target="_blank" rel="noopener">
+                  CyberWire Daily Podcast
+                </a>
+                – daily briefings on cyber events shaping the world.
+              </li>
+            </ul>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Meet the CyberHubJo core team of cybersecurity researchers, architects, and community leaders."
+    />
+    <title>CyberHubJo | Our Team</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css?v=20240523" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="index.html">
+          <img
+            src="https://i.ibb.co/TMT9mzGX/Logo.jpg"
+            alt="CyberHubJo logo"
+            class="brand-logo"
+            width="64"
+            height="36"
+          />
+          <span class="brand-name">CyberHubJo</span>
+        </a>
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          aria-controls="primary-navigation"
+          type="button"
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav aria-label="Primary">
+          <ul class="nav-links" id="primary-navigation">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="team.html" aria-current="page">Our Team</a></li>
+            <li><a href="publications.html">Publications</a></li>
+            <li><a href="activities.html">Activities</a></li>
+            <li><a href="gallery.html">Gallery</a></li>
+            <li><a href="resources.html">Useful Resources</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <div>
+            <h1>The minds powering CyberHubJo</h1>
+            <p>
+              Our multidisciplinary team blends academic excellence, industry
+              expertise, and community leadership to drive impactful
+              cybersecurity programs for Jordan and the region.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Leadership &amp; Contributors</h2>
+        <p class="section-intro">
+          Each member brings a unique perspective to strengthening Jordan&apos;s
+          cyber defense posture through research, innovation, and outreach.
+        </p>
+        <div class="cards team-grid" role="list">
+          <article class="card card-founder team-card team-card--hatem" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/5hH03Fn4/Hatem.png"
+                alt="Portrait of Hatem Mosa"
+                loading="lazy"
+              />
+              <div>
+                <h3>Hatem Mosa</h3>
+                <span class="badge badge-founder">Founder of CyberHubJo</span>
+                <p class="role">Cybersecurity Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:h.mosa@cyberhubjo.com">h.mosa@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Founder of CyberHubJo, Hatem Mosa is a cybersecurity specialist
+              and PSUT PhD candidate shaping blockchain security research and
+              regional awareness initiatives...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/hatem-mosa" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=DIjlcAYAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Hatem-Mosa-2?ev=hdr_xprf" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--eman" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/qM2Q0bs0/Eman.jpg"
+                alt="Portrait of Eman Alnagi"
+                loading="lazy"
+              />
+              <div>
+                <h3>Eman Alnagi</h3>
+                <p class="role">Research Associate</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:e.alnagi@cyberhubjo.com">e.alnagi@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Eman Alnagi is a PSUT PhD candidate with international
+              postgraduate studies and 11 years of lecturing experience
+              spanning software engineering, NLP, cryptography, and AI...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/eman-alnagi/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=4xD9oKgAAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Eman-Alnagi?ev=prf_overview" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--amro" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/nqV9mCR9/Amro.png"
+                alt="Portrait of Amro Saleh"
+                loading="lazy"
+              />
+              <div>
+                <h3>Amro Saleh</h3>
+                <p class="role">Scientific Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:a.saleh@cyberhubjo.com">a.saleh@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Amro Saleh is a PSUT PhD researcher focused on distributed data
+              and AI systems, blending industry experience with secure,
+              scalable techniques for real-world deployments...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/amro-saleh-b50ab720a/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=O94CIikAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Amro-Saleh/research" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--yasmeen" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/3tqr740/Yasmeen.png"
+                alt="Portrait of Yasmeen Alslman"
+                loading="lazy"
+              />
+              <div>
+                <h3>Yasmeen Alslman</h3>
+                <p class="role">Scientific Research Advisor</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:y.alslman@cyberhubjo.com">y.alslman@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Yasmeen Alslman is a PSUT researcher dedicated to cybersecurity
+              and AI, specializing in adversarial machine learning, IDS
+              innovation, and emerging LLM exploration...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/yasmeen-alslman-61468a198/?originalSubdomain=jo" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?user=5gHaQkoAAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Yasmeen-Alslman" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--saleem" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/dsZ2by9n/Saleem.png"
+                alt="Portrait of Saleem Alsaraireh"
+                loading="lazy"
+              />
+              <div>
+                <h3>Saleem Alsaraireh</h3>
+                <p class="role">Cybersecurity Academic Liaison Officer</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:s.alsaraireh@cyberhubjo.com">s.alsaraireh@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Saleem Alsaraireh is a PSUT PhD candidate and Jordan Armed Forces
+              Lieutenant Colonel advancing military communications and
+              cybersecurity leadership across 17+ years of service...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/saleem-alsaraireh-aa6611352/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=V_GTO78AAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Saleem-Alsaraireh" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--ebtehal" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/PvDCyqzf/Ebtihal.png"
+                alt="Portrait of Ebtehal Omoush"
+                loading="lazy"
+              />
+              <div>
+                <h3>Ebtehal Omoush</h3>
+                <p class="role">Scientific Events Coordinator</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:e.omoush@cyberhubjo.com">e.omoush@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              Ebtehal Hamdan Omoush is a PSUT PhD candidate and Scientific
+              Events Coordinator building on Computer Science degrees from
+              Al al-Bayt University and her current work there...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/ebtehal-omoush-76659645/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=WIvIULEAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Ebtehal-Omoush-2" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+
+          <article class="card team-card team-card--abedlrahman" role="listitem">
+            <div class="card-header">
+              <img
+                src="https://i.ibb.co/dJxLvMhn/Abdulrahman.jpg"
+                alt="Portrait of AbedlRahman Almodawar"
+                loading="lazy"
+              />
+              <div>
+                <h3>AbedlRahman Almodawar</h3>
+                <p class="role">Research Publication Coordinator</p>
+                <p class="email">
+                  <strong>CyberHub Email:</strong>
+                  <a href="mailto:a.almodawar@cyberhubjo.com">a.almodawar@cyberhubjo.com</a>
+                </p>
+              </div>
+            </div>
+            <p class="bio">
+              AbedlRahman Almodawar is a PSUT PhD candidate and veteran
+              lecturer whose research centers on AI, cloud and edge computing,
+              and cybersecurity for modern learning environments...
+            </p>
+            <div class="links">
+              <a href="https://www.linkedin.com/in/abedlrahman-almodawar-74b90128/" target="_blank" rel="noopener">LinkedIn</a>
+              <a href="https://scholar.google.com/citations?hl=en&amp;user=fl0s05oAAAAJ&amp;view_op=list_works&amp;sortby=pubdate" target="_blank" rel="noopener">Google Scholar</a>
+              <a href="https://www.researchgate.net/profile/Abedlrahman-Almodawar?ev=hdr_xprf" target="_blank" rel="noopener">ResearchGate</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        © <span id="year"></span> CyberHubJo. All rights reserved. Reach us at
+        <a href="mailto:info@cyberhubjo.com">info@cyberhubjo.com</a>.
+      </p>
+    </footer>
+
+    <script src="assets/js/main.js?v=20240523"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- keep the team shuffle by applying CSS ordering so all eight profiles stay in view while Hatem stays paired first
- bump the shared CSS/JS cache-busting query strings to 20240523 across all pages so deployments load the refreshed assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9732d5474832dbc5f99dc730c741b